### PR TITLE
Only send getLegendGraphics request if layer has Style tag

### DIFF
--- a/lib/GeoExt/widgets/WMSLegend.js
+++ b/lib/GeoExt/widgets/WMSLegend.js
@@ -149,7 +149,9 @@ GeoExt.WMSLegend = Ext.extend(GeoExt.LayerLegend, {
                 url = decodeURIComponent(url);
             }
         }
-        if(!url) {
+		/* added check if style is there - and if layer is a Layer Group it 
+		 * doesnt have <Style> (or LegendURL>) and no request is sent	*/
+        if( (!url) && (styleName.length > 0) ) { 
             url = layer.getFullRequestString({
                 REQUEST: "GetLegendGraphic",
                 WIDTH: null,


### PR DESCRIPTION
Only send getLegendGraphics request if layer has Style tag in getCapabilities - so request for Legend graphics will not be sent if layer is a Layer Group (from GeoServer).