### PR TITLE
tileFullExtent should not replace maxExtent

### DIFF
--- a/lib/GeoExt/data/PrintProvider.js
+++ b/lib/GeoExt/data/PrintProvider.js
@@ -786,7 +786,7 @@ GeoExt.data.PrintProvider = Ext.extend(Ext.util.Observable, {
                         formatSuffix: layer.formatSuffix,
                         tileOrigin: [layer.tileOrigin.lon, layer.tileOrigin.lat],
                         tileSize: [layer.tileSize.w, layer.tileSize.h],
-                        maxExtent: (layer.tileFullExtent != null) ? layer.tileFullExtent.toArray() : layer.maxExtent.toArray(),
+                        maxExtent: layer.maxExtent.toArray(),
                         zoomOffset: layer.zoomOffset,
                         resolutions: layer.serverResolutions || layer.resolutions
                     });


### PR DESCRIPTION
if it replaces the maxExtent, the grid calculation is changed and the tiles positions are shifted.
beside tileFullExtent is a performance related parameter, used to tell OpenLayer to not load tiles outside of a defined extent and save time doing useless requests, but this is not so important for Mapfish Print.

