### PR TITLE
Make sure maxValue is set in ZoomSlider

### DIFF
--- a/lib/GeoExt/widgets/ZoomSlider.js
+++ b/lib/GeoExt/widgets/ZoomSlider.js
@@ -217,7 +217,7 @@ GeoExt.ZoomSlider = Ext.extend(Ext.slider.SingleSlider, {
                 this.minValue = Math.max(minZoom, layer.minZoomLevel || 0);
             }
             if(this.initialConfig.maxValue === undefined) {
-                this.maxValue = layer.minZoomLevel == null ?
+                this.maxValue = layer.maxZoomLevel == null ?
                     layer.numZoomLevels - 1 : layer.maxZoomLevel;
             }
             // reset the thumb value so it gets repositioned when we call update


### PR DESCRIPTION
Currently if minZoomLevel is set on the base layer, but maxZoomLevel is not set, this will result in the maxValue of the slider being undefined and it will not work properly anymore.

I think there is simply a typo in the current code base, see the attached PR for a fix.