### PR TITLE
fixed WFS caps reader when no featuretypes are available

### DIFF
--- a/lib/GeoExt/data/WFSCapabilitiesReader.js
+++ b/lib/GeoExt/data/WFSCapabilitiesReader.js
@@ -91,8 +91,8 @@ Ext.extend(GeoExt.data.WFSCapabilitiesReader, Ext.data.DataReader, {
         if(typeof data === "string" || data.nodeType) {
             data = this.meta.format.read(data);
         }
-
-        var featureTypes = data.featureTypeList.featureTypes;
+        var featureTypes = data.featureTypeList ?
+            data.featureTypeList.featureTypes : [];
         var fields = this.recordType.prototype.fields;
 
         var featureType, values, field, v, parts, layer;


### PR DESCRIPTION
When no FeatureTypes are available in the service, ```data.featureTypeList``` is undefined, which leads to a store load exception.