### PR TITLE
Fix handling of WMTS Rest URLs with template for mfp v3

### DIFF
--- a/lib/GeoExt/data/MapFishPrintv3Provider.js
+++ b/lib/GeoExt/data/MapFishPrintv3Provider.js
@@ -360,7 +360,10 @@ GeoExt.data.MapFishPrintv3Provider = Ext.extend(GeoExt.data.PrintProviderBase, {
                                 * OpenLayers.METERS_PER_INCH
                                 * OpenLayers.INCHES_PER_UNIT[layer.units],
                             tileSize: [layer.tileSize.w, layer.tileSize.h],
-                            topLeftCorner: [layer.tileOrigin.lon, layer.tileOrigin.lat]
+                            topLeftCorner: [
+                                layer.getTileOrigin().lon,
+                                layer.getTileOrigin().lat
+                            ]
                         });
                     });
                 }

--- a/lib/GeoExt/data/PrintProviderBase.js
+++ b/lib/GeoExt/data/PrintProviderBase.js
@@ -631,10 +631,7 @@ GeoExt.data.PrintProviderBase = Ext.extend(Ext.util.Observable, {
      *  Converts the provided url to an absolute url.
      */
     getAbsoluteUrl: function(url) {
-        if (Ext.isSafari) {
-            url = url.replace(/{/g, '%7B');
-            url = url.replace(/}/g, '%7D');
-        }
+        url = encodeURI(url);
         var a;
         if (Ext.isIE6 || Ext.isIE7 || Ext.isIE8) {
             a = document.createElement("<a href='" + url + "'/>");
@@ -646,7 +643,7 @@ GeoExt.data.PrintProviderBase = Ext.extend(Ext.util.Observable, {
             a = document.createElement("a");
             a.href = url;
         }
-        return a.href;
+        return decodeURI(a.href);
     },
 
     /** private: property[encoders]

--- a/tests/lib/GeoExt/data/MapFishPrintv3PrintProvider.html
+++ b/tests/lib/GeoExt/data/MapFishPrintv3PrintProvider.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html debug="true">
+  <head>
+    <script type="text/javascript" src="../../../../../openlayers/lib/OpenLayers.js"></script>
+    <script type="text/javascript" src="../../../../../ext/adapter/ext/ext-base.js"></script>
+    <script type="text/javascript" src="../../../../../ext/ext-all-debug.js"></script>
+    <script type="text/javascript" src="../../../../lib/GeoExt.js"></script>
+
+    <script type="text/javascript">
+
+        function test_encodeLayer_wmts_rest_url(t) {
+            t.plan(2);
+            var printProvider = new GeoExt.data.MapFishPrintv3Provider({
+                url: '/print/'
+            });
+
+            var map = new OpenLayers.Map("map");
+            var layer = new OpenLayers.Layer.WMTS({
+                requestEncoding: 'REST',
+                url: 'http://domain.tld/proxy/wmts/3_swissimage/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png',
+                name: 'swissimage',
+                layer: '3_swissimage',
+                formatSuffix: 'png',
+                visibility: false,
+                style: 'default',
+                matrixSet: 'epsg',
+                matrixIds: null,
+                maxExtent: new OpenLayers.Bounds(2544650.0, 1073801.0, 2691212.0, 1171318.0),
+                projection: new OpenLayers.Projection('EPSG:2056'),
+                units: 'm',
+                formatSuffix: 'png',
+                serverResolutions: [4000, 3750, 3500, 3250]
+            });
+            map.addLayer(layer);
+
+            var encoded = printProvider.encodeLayer(layer, undefined);
+            var expect = 'http://domain.tld/proxy/wmts/3_swissimage/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png';
+            t.eq(encoded.baseURL, expect, 'url is not changed');
+
+            layer.url = 'http://domain.tld/proxy/wmts/';
+            encoded = printProvider.encodeLayer(layer, undefined);
+            expect = 'http://domain.tld/proxy/wmts/1.0.0/3_swissimage/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png';
+            t.eq(encoded.baseURL, expect, 'url is completed');
+        }
+
+    </script>
+  </head>
+  <body>
+    <div id="map" style="width:400px; height:300px"></div>
+    <div id="legend" style="width:200px; height:300px"></div>
+  </body>
+</html>

--- a/tests/lib/GeoExt/data/PrintProvider.html
+++ b/tests/lib/GeoExt/data/PrintProvider.html
@@ -88,12 +88,13 @@
         }
 
         function test_getAbsoluteUrl(t) {
-            t.plan(2);
+            t.plan(3);
 
             var getAbsoluteUrl = GeoExt.data.PrintProvider.prototype.getAbsoluteUrl;
             var baseUrl = parent.location.href.substr(0, parent.location.href.indexOf("/tests/run-tests.html"));
             t.eq(getAbsoluteUrl("/foo/bar.html"), location.protocol + "//" + location.host + "/foo/bar.html", "Relative url converted to absolute url correctly.");
             t.eq(getAbsoluteUrl("../../../../bar.html"), baseUrl + "/bar.html", "Relative url with relative path converted to absolute url correctly.");
+            t.eq(getAbsoluteUrl("/a?b=c&d=e"), location.protocol + "//" + location.host + "/a?b=c&d=e", "Relative url converted to absolute url correctly.");
         }
 
         function test_print(t) {
@@ -365,7 +366,7 @@
                     "name":"markers",
                     "opacity":1
                 }, {
-                    baseURL:"http://wmts0.geo.admin.ch/1.0.0/pixelkarte/default/%7Bdate%7D/%7BTileMatrixSet%7D/%7BTileMatrix%7D/%7BTileRow%7D/%7BTileCol%7D.png",
+                    baseURL:"http://wmts0.geo.admin.ch/1.0.0/pixelkarte/default/{date}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png",
                     opacity:1,
                     type:"WMTS",
                     layer:"pixelkarte",

--- a/tests/lib/GeoExt/data/PrintProvider.html
+++ b/tests/lib/GeoExt/data/PrintProvider.html
@@ -92,7 +92,7 @@
 
             var getAbsoluteUrl = GeoExt.data.PrintProvider.prototype.getAbsoluteUrl;
             var baseUrl = parent.location.href.substr(0, parent.location.href.indexOf("/tests/run-tests.html"));
-            t.eq(getAbsoluteUrl("/foo/bar.html"), location.protocol + "//" + location.host + (location.port && ":" + location.port) + "/foo/bar.html", "Relative url converted to absolute url correctly.");
+            t.eq(getAbsoluteUrl("/foo/bar.html"), location.protocol + "//" + location.host + "/foo/bar.html", "Relative url converted to absolute url correctly.");
             t.eq(getAbsoluteUrl("../../../../bar.html"), baseUrl + "/bar.html", "Relative url with relative path converted to absolute url correctly.");
         }
 

--- a/tests/list-tests.html
+++ b/tests/list-tests.html
@@ -8,6 +8,7 @@
   <li>lib/GeoExt/data/LayerRecord.html</li>
   <li>lib/GeoExt/data/LayerReader.html</li>
   <li>lib/GeoExt/data/LayerStore.html</li>
+  <li>lib/GeoExt/data/MapFishPrintv3PrintProvider.html</li>
   <li>lib/GeoExt/data/PrintPage.html</li>
   <li>lib/GeoExt/data/PrintProvider.html</li>
   <li>lib/GeoExt/data/ScaleStore.html</li>


### PR DESCRIPTION
Currently when a WMTS Rest layer has a template URL like the following:

> http://domain.tld/proxy/wmts/3_swissimage/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png

..., the following URL is used for the print (with v3):

> http://domain.tld/proxy/wmts/3_swissimage/%7BTileMatrixSet%7D/%7BTileMatrix%7D/%7BTileCol%7D/%7BTileRow%7D.png/1.0.0/3_swissimage/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png

The problem is that "{" and "}" are replaced with "%7B" and "%7D" when getting the [absolute URL](https://github.com/geoext/geoext/blob/21fbccecb4a95121dd13168d7fe44f17aad5bed3/lib/GeoExt/data/PrintProviderBase.js#L633) for a layer. Because now the URL no longer contains the character "{", the WMTS template variables are [appended](https://github.com/geoext/geoext/blob/21fbccecb4a95121dd13168d7fe44f17aad5bed3/lib/GeoExt/data/MapFishPrintv3Provider.js#L324).

The proposed fix is to replace "%7B" and "%7D" with "{" and "}".