### PR TITLE
Use the job object

### DIFF
--- a/lib/GeoExt/data/MapFishPrintv3Provider.js
+++ b/lib/GeoExt/data/MapFishPrintv3Provider.js
@@ -238,8 +238,7 @@ GeoExt.data.MapFishPrintv3Provider = Ext.extend(GeoExt.data.PrintProviderBase, {
             jsonData: jsonData,
             headers: { "Content-Type": "application/json; charset=" + this.encoding },
             success: function(response) {
-                var ref = Ext.decode(response.responseText).ref;
-                callback(ref);
+                callback(Ext.decode(response.responseText));
             },
             failure: function(response) {
                 this.fireEvent("printexception", this, response);
@@ -252,18 +251,18 @@ GeoExt.data.MapFishPrintv3Provider = Ext.extend(GeoExt.data.PrintProviderBase, {
     /** api: method[getStatus]
      *  Get the status of a specific job
      *
-     *  :param ref: ``String`` the job reference
+     *  :param job: ``String`` the job specification
      *  :param callback: ``Function`` the function called with the status
      */
-    getStatus: function(ref, callback) {
+    getStatus: function(job, callback) {
         Ext.Ajax.request({
-            url: this.url + '/status/' + ref + '.json',
+            url: this.url + '/status/' + job.ref + '.json',
             method: 'GET',
             success: function(response) {
-                callback(ref, true, Ext.decode(response.responseText));
+                callback(job, true, Ext.decode(response.responseText));
             },
             failure: function(response) {
-                callback(ref, false);
+                callback(job, false);
                 this.fireEvent("printexception", this, response);
             },
             params: this.baseParams,
@@ -274,10 +273,10 @@ GeoExt.data.MapFishPrintv3Provider = Ext.extend(GeoExt.data.PrintProviderBase, {
     /** api: method[getDownloadURL]
      *  Get the URL to download the result for a job
      *
-     *  :param ref: ``String`` the job reference
+     *  :param job: ``String`` the job specification
      */
-    getDownloadURL: function(ref) {
-        return this.url + '/report/' + ref;
+    getDownloadURL: function(job) {
+        return this.url + '/report/' + job.ref;
     },
 
     /** private: property[encodersOverride]


### PR DESCRIPTION
In place of the job ref, to be able to use other parameters in the
application.

Required to use the position added by: mapfish/mapfish-print#239