### PR TITLE
Convert containsBounds to intersects

### DIFF
--- a/lib/GeoExt/data/PrintProviderBase.js
+++ b/lib/GeoExt/data/PrintProviderBase.js
@@ -679,7 +679,8 @@ GeoExt.data.PrintProviderBase = Ext.extend(Ext.util.Observable, {
                     }
                     else {
                         if (!feature.geometry.bounds ||
-                                !bounds.containsBounds(feature.geometry.bounds, true)) {
+                                !bounds.toGeometry().intersects(
+                                    feature.geometry.bounds.toGeometry())) {
                             return;
                         }
                     }


### PR DESCRIPTION
containsBounds don't works if not any points will be in the bound e.-g.

```
      secound
      -------
     |       |
f  -----     |
i |  |  |    |
r |  |  |    |
s  -----     |
t    |       |
      -------
```

initial issues: https://github.com/camptocamp/c2cgeoportal/issues/2021, https://github.com/camptocamp/c2cgeoportal/issues/1997