### PR TITLE
Rename links inside gh-pages from geoext3 to geoext

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,9 +32,9 @@
         </a>
         <div class="nav-collapse collapse pull-right">
           <ul class="nav">
-            <li><a href="https://geoext.github.io/geoext3/v3.3.2/docs/"><i class="icon-th-list icon-big"></i> Documentation</a></li>
-            <li><a href="https://geoext.github.io/geoext3/v3.3.2/docs-w-ext/"><i class="icon-list icon-big"></i> Documentation (w/ Ext)</a></li>
-            <li><a href="https://github.com/geoext/geoext3"><i class="icon-folder-open icon-big"></i> Code</a></li>
+            <li><a href="https://geoext.github.io/geoext/v3.3.2/docs/"><i class="icon-th-list icon-big"></i> Documentation</a></li>
+            <li><a href="https://geoext.github.io/geoext/v3.3.2/docs-w-ext/"><i class="icon-list icon-big"></i> Documentation (w/ Ext)</a></li>
+            <li><a href="https://github.com/geoext/geoext"><i class="icon-folder-open icon-big"></i> Code</a></li>
           </ul>
         </div>
       </div>
@@ -60,8 +60,8 @@
         built atop the following official installments of it's base libraries;
         OpenLayers 4.6.5 and ExtJS 6.2.0. The versions of GeoExt that support
         these libraries are
-        <a href="https://github.com/geoext/geoext3/releases/tag/v3.3.2">version
-        3.3.2</a> and the older <a href="https://github.com/geoext/geoext3/releases/tag/v3.2.0">version
+        <a href="https://github.com/geoext/geoext/releases/tag/v3.3.2">version
+        3.3.2</a> and the older <a href="https://github.com/geoext/geoext/releases/tag/v3.2.0">version
       3.2.0</a>.
       </p>
       <p>
@@ -87,13 +87,13 @@
           GeoExt 3 is a rather young project, a lot of the code and structural
           decisions come from a code sprint in Bonn. 9 developers gathered there
           from 2015-06-17 to 2015-06-19. We are deeply grateful that
-          <a href="https://github.com/geoext/geoext3/wiki/GeoExt-3-Codesprint#sponsors">our
+          <a href="https://github.com/geoext/geoext/wiki/GeoExt-3-Codesprint#sponsors">our
           sponsors</a> helped to start GeoExt 3.
         </p>
         <p>
           Now, have a look at the examples below, read the API documentation, the
           API documentation (including ExtJS classes) or
-          <a href="https://github.com/geoext/geoext3">checkout the code</a>
+          <a href="https://github.com/geoext/geoext">checkout the code</a>
         </p>
 
         <table class="table table-hover">
@@ -180,15 +180,15 @@
           There are multiple ways to download and use GeoExt. 
           <ul>
               <li>using <a href="https://www.npmjs.com/package/@geoext/geoext">npm</a>: <code>npm install @geoext/geoext</code>		  
-              <li>by cloning with git: <code>git clone https://github.com/geoext/geoext3.git</code></li>
-              <li>downloading the latest official <a href="https://github.com/geoext/geoext3/archive/v3.2.0.zip">release</a></li>
-              <li><a href="https://github.com/geoext/geoext3/archive/master.zip">downloading the latest raw source code</a></li>
+              <li>by cloning with git: <code>git clone https://github.com/geoext/geoext.git</code></li>
+              <li>downloading the latest official <a href="https://github.com/geoext/geoext/archive/v3.2.0.zip">release</a></li>
+              <li><a href="https://github.com/geoext/geoext/archive/master.zip">downloading the latest raw source code</a></li>
           </ul>
         </p>
         <p>
           Each approach has upsides and downsides, so if you want to use GeoExt
           in your project, please refer to these more detailed instructions with
-          <a href="https://github.com/geoext/geoext3#how-to-use-geoext-3-inside-your-sencha-app">hints
+          <a href="https://github.com/geoext/geoext#how-to-use-geoext-3-inside-your-sencha-app">hints
           on how to download / use GeoExt</a> efficiently.
         </p>
       </div>
@@ -204,19 +204,19 @@
 
       <div class="row">
         <div class="span4">
-          <a href="https://geoext.github.io/geoext3/master/examples/component/map.html" class="big-link">
+          <a href="https://geoext.github.io/geoext/master/examples/component/map.html" class="big-link">
             <h3>Map</h3>
             <p>A basic Map component in a panel.</p>
           </a>
         </div>
         <div class="span4">
-          <a href="https://geoext.github.io/geoext3/master/examples/component/overviewMap.html" class="big-link">
+          <a href="https://geoext.github.io/geoext/master/examples/component/overviewMap.html" class="big-link">
             <h3>Overview Map</h3>
             <p>Various versions of the OverviewMap component.</p>
           </a>
         </div>
         <div class="span4">
-          <a href="https://geoext.github.io/geoext3/master/examples/state/stateful-map.html" class="big-link">
+          <a href="https://geoext.github.io/geoext/master/examples/state/stateful-map.html" class="big-link">
             <h3>Map Permalinks</h3>
             <p>Create a stateful map and generate map permalinks.</p>
           </a>
@@ -225,19 +225,19 @@
 
       <div class="row">
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/tree/panel.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/tree/panel.html" class="big-link">
                   <h3>Tree Panel</h3>
                   <p>Control the layers of you map with a hierarchical tree.</p>
               </a>
           </div>
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/tree/tree-legend-simple.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/tree/tree-legend-simple.html" class="big-link">
                   <h3>Tree Panel with legends</h3>
                   <p>See how to include legends in the tree panel.</p>
               </a>
           </div>
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/popup/gx-popup.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/popup/gx-popup.html" class="big-link">
                   <h3>Popup</h3>
                   <p>See how to create popups that are anchored to a location.</p>
               </a>
@@ -246,19 +246,19 @@
 
       <div class="row">
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/renderer/renderer.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/renderer/renderer.html" class="big-link">
                   <h3>Feature Renderer</h3>
                   <p>See how to render styled features in arbitrary components.</p>
               </a>
           </div>
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/mapviewform/mapviewform.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/mapviewform/mapviewform.html" class="big-link">
                   <h3>OlObject</h3>
                   <p>See how to wrap OpenLayers objects as ExtJS model records.</p>
               </a>
           </div>
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/filtered-heatmap/filtered-heatmap.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/filtered-heatmap/filtered-heatmap.html" class="big-link">
                   <h3>Filtered Heatmap</h3>
                   <p>See how to adapt OpenLayers maps interactively with controls.</p>
               </a>
@@ -267,20 +267,20 @@
 
       <div class="row">
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/features/grid.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/features/grid.html" class="big-link">
                   <h3>Feature Grid</h3>
                   <p>See how to display OpenLayers features in a grid and interact between grid and map.</p>
               </a>
           </div>
 
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/features/grid-map-selection.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/features/grid-map-selection.html" class="big-link">
                   <h3>Grid with Feature Selection</h3>
                   <p>Synchronize selection of features between a grid and a layer.</p>
               </a>
           </div>
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/features/grid-paging.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/features/grid-paging.html" class="big-link">
                   <h3>Grid with OGC Filters and Paging</h3>
                   <p>Page through WFS records in a grid, synchronized with a layer.</p>
               </a>
@@ -289,19 +289,19 @@
 
       <div class="row">
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/features/grid-filter.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/features/grid-filter.html" class="big-link">
                   <h3>Grid with OGC Filters for WMS and WFS Layers</h3>
                   <p>Use ExtJS grid filters to filter WMS and WFS layers in a map with OGC compliant filters</p>
               </a>
           </div>
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/geocoder/geocoder-combo.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/geocoder/geocoder-combo.html" class="big-link">
                   <h3>GeoCoder Combo Box</h3>
                   <p>Search for locations using geocoding provided by the Nominatim API.</p>
               </a>
           </div>
           <div class="span4">
-              <a href="https://geoext.github.io/geoext3/master/examples/print/basic-mapfish.html" class="big-link">
+              <a href="https://geoext.github.io/geoext/master/examples/print/basic-mapfish.html" class="big-link">
                   <h3>Mapfish Print</h3>
                   <p>See how to talk with a mapfish print servlet (v.3).</p>
               </a>
@@ -315,13 +315,13 @@
 
       <div class="row">
         <div class="span4">
-          <a href="https://geoext.github.io/geoext3/master/examples/modern-map/modern-map.html" class="big-link">
+          <a href="https://geoext.github.io/geoext/master/examples/modern-map/modern-map.html" class="big-link">
             <h3>Map</h3>
             <p>A basic Map component in a modern toolkit app.</p>
           </a>
         </div>
         <div class="span4">
-          <a href="https://geoext.github.io/geoext3/master/examples/modern-layerlist/modern-layerlist.html" class="big-link">
+          <a href="https://geoext.github.io/geoext/master/examples/modern-layerlist/modern-layerlist.html" class="big-link">
             <h3>LayerList</h3>
             <p>A LayerList component in a modern toolkit app.</p>
           </a>
@@ -361,7 +361,7 @@
             <td>6.2.0</td>
             <td>3.3.2</td>
             <td>
-              <a href="https://github.com/geoext/geoext3/releases/tag/v3.3.2">released</a>
+              <a href="https://github.com/geoext/geoext/releases/tag/v3.3.2">released</a>
             </td>
           </tr>
           <tr>
@@ -369,7 +369,7 @@
             <td>6.2.0</td>
             <td>3.2.0</td>
             <td>
-              <a href="https://github.com/geoext/geoext3/releases/tag/v3.2.0">released</a>
+              <a href="https://github.com/geoext/geoext/releases/tag/v3.2.0">released</a>
             </td>
           </tr>
           <tr>
@@ -377,7 +377,7 @@
             <td>6.2.0</td>
             <td>3.1.0</td>
             <td>
-              <a href="https://github.com/geoext/geoext3/releases/tag/v3.1.0">released</a>
+              <a href="https://github.com/geoext/geoext/releases/tag/v3.1.0">released</a>
             </td>
           </tr>
           <tr>
@@ -385,7 +385,7 @@
             <td>6.2.0</td>
             <td>3.0.0</td>
             <td>
-              <a href="https://github.com/geoext/geoext3/releases/tag/v3.0.0">released</a>
+              <a href="https://github.com/geoext/geoext/releases/tag/v3.0.0">released</a>
             </td>
           </tr>
           <tr>
@@ -419,12 +419,12 @@
 
   <div class="row">
     <div class="span4">
-      <a href="https://github.com/geoext/geoext3" class="big-link">
+      <a href="https://github.com/geoext/geoext" class="big-link">
         <h3>Fork the repo</h3>
       </a>
     </div>
     <div class="span4">
-      <a href="https://github.com/geoext/geoext3/issues" class="big-link">
+      <a href="https://github.com/geoext/geoext/issues" class="big-link">
         <h3>Open an issue</h3>
       </a>
     </div>
@@ -438,7 +438,7 @@
   </div>
     <footer class="footer">
       <p>
-        Code licensed under the <a href="https://raw.githubusercontent.com/geoext/geoext3/master/LICENSE">GPL-3-license</a>.
+        Code licensed under the <a href="https://raw.githubusercontent.com/geoext/geoext/master/LICENSE">GPL-3-license</a>.
         All documentation <a href="https://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.
       </p>
       <p>


### PR DESCRIPTION
This changes all links inside of https://geoext.github.io/geoext/
from https://geoext.github.io/geoext3/ to https://geoext.github.io/geoext/
from https://github.com/geoext/geoext3 to https://github.com/geoext/geoext