### PR TITLE
Deploy gh pages to geoext3

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -112,3 +112,11 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./master
         destination_dir: ./master
+
+    - name: Deploy gh-pages to geoext3 path
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        deploy_key: ${{ secrets.GEOEXT_GITHUB_IO_DEPLOY_KEY }}
+        external_repository: geoext/geoext.github.io
+        publish_dir: ./master
+        destination_dir: ./geoext3/master/

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -73,3 +73,12 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./${GITHUB_REF##*/}
         destination_dir: ./${GITHUB_REF##*/}
+
+
+    - name: Deploy gh-pages to geoext3 path
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        deploy_key: ${{ secrets.GEOEXT_GITHUB_IO_DEPLOY_KEY }}
+        external_repository: geoext/geoext.github.io
+        publish_dir: ./${GITHUB_REF##*/}
+        destination_dir: ./geoext3/${GITHUB_REF##*/}


### PR DESCRIPTION
This deploys the gh pages also to https://geoext.github.io/geoext3/ (not only to https://geoext.github.io/geoext). This ensures that any existing links to the api docs will still work in the future.