### PR TITLE
Ensure correct selectedFeatures is used for GeoExt.selection.FeatureModelMixin

### DIFF
--- a/classic/selection/FeatureModelMixin.js
+++ b/classic/selection/FeatureModelMixin.js
@@ -128,8 +128,6 @@ Ext.define('GeoExt.selection.FeatureModelMixin', {
     bindFeatureModel: function() {
         var me = this;
 
-        me.selectedFeatures = new ol.Collection();
-
         // detect a layer from the store if not passed in
         if (!me.layer || !(me.layer instanceof ol.layer.Vector)) {
             var store = me.getStore();
@@ -151,6 +149,8 @@ Ext.define('GeoExt.selection.FeatureModelMixin', {
     bindOlEvents: function() {
         if (!this.bound_) {
             var me = this;
+
+            me.selectedFeatures = new ol.Collection();
 
             // change style of selected feature
             me.selectedFeatures.on('add', me.onSelectFeatAdd);


### PR DESCRIPTION
Fix for #692 - creating the `ol.Collection()` in the same place as adding the listeners ensures the correct collection is used. 
Still unsure why `bindFeatureModel` is called multiple times in my application. 

Unable to request a review so pinging @simonseyock directly. 

Fixes https://github.com/compassinformatics/cpsi-mapview/issues/411