### PR TITLE
Fix for removing a selected features throwing a key error

### DIFF
--- a/classic/selection/FeatureModelMixin.js
+++ b/classic/selection/FeatureModelMixin.js
@@ -311,7 +311,8 @@ Ext.define('GeoExt.selection.FeatureModelMixin', {
         var selFeature = record.getFeature();
 
         // toggle feature's selection state
-        selFeature.set(me.selectedFeatureAttr, isSelected);
+        var silent = true;
+        selFeature.set(me.selectedFeatureAttr, isSelected, silent);
 
         if (isSelected) {
             me.selectedFeatures.push(selFeature);

--- a/test/spec/GeoExt/selection/FeatureRowModel.test.js
+++ b/test/spec/GeoExt/selection/FeatureRowModel.test.js
@@ -327,4 +327,72 @@ describe('GeoExt.selection.FeatureRowModel', function() {
             }
         );
     });
+
+    describe('selection and clearing of features with filters', function() {
+        var selModel;
+        var grid;
+        var featStore;
+        var selRec;
+        var selFeat;
+        var layer;
+
+        beforeEach(function() {
+            var feat = new ol.Feature({fid: 1});
+            var coll = new ol.Collection();
+            coll.push(feat);
+
+            layer = new ol.layer.Vector({
+                source: new ol.source.Vector({
+                    features: coll
+                })
+            });
+
+            featStore =
+                Ext.create('GeoExt.data.store.Features', {
+                    layer: layer
+                });
+
+            featStore.filterBy(function(rec) {
+                return rec.get('fid') !== -1;
+            });
+
+            selModel = Ext.create('GeoExt.selection.FeatureRowModel', {
+                mode: 'SINGLE'
+            });
+            // feature grid with a feature selection model
+            grid = Ext.create('Ext.grid.Panel', {
+                store: featStore,
+                selModel: selModel
+            });
+            selRec = featStore.getAt(0);
+            selFeat = selRec.getFeature();
+        });
+
+        afterEach(function() {
+            selModel.destroy();
+            featStore.destroy();
+            grid.destroy();
+            selModel = null;
+            featStore = null;
+            grid = null;
+            selRec = null;
+            selFeat = null;
+        });
+
+        it('selection is cleared when layer is cleared', function() {
+            grid.getView().setSelection(selRec);
+            layer.getSource().clear();
+            expect(selModel.selectedFeatures.getLength()).to.be(0);
+            expect(featStore.getData().getCount()).to.be(0);
+            expect(layer.getSource().getFeatures().length).to.be(0);
+        });
+
+        it('selection is cleared when feature is removed', function() {
+            grid.getView().setSelection(selRec);
+            layer.getSource().removeFeature(selFeat);
+            expect(selModel.selectedFeatures.getLength()).to.be(0);
+            expect(featStore.getData().getCount()).to.be(0);
+            expect(layer.getSource().getFeatures().length).to.be(0);
+        });
+    });
 });


### PR DESCRIPTION
If a feature is selected and then removed from a layer an error is thrown. The issue is caused due to the logic in [Ext.util.Collection](https://docs.sencha.com/extjs/6.7.0/classic/Ext.util.Collection.html#method-itemChanged
) (although it may not be a bug in ExtJS). 

In the `itemChanged` function the feature is already removed, so when searched for by key `filterChanged` is set to `true`:

```js
	if (filtered) {
		index = me.indexOfKey(keyChanged ? oldKey : newKey); //  as the array is empty then index is -1
		wasFiltered = (index < 0); // this is then true
		itemFiltered = me.isItemFiltered(item);
		filterChanged = (wasFiltered !== itemFiltered); // also then true
```

Then the `toAdd` array is populated which triggers an `add` event which adds a record to the store, even when everything is cleared:

```js
	if (filterChanged) {
		if (itemFiltered) {
			toRemove = [ item ];
			newIndex = -1;
		} else {
			toAdd = [ item ]; // then end up here and an `add` event is triggered
			newIndex = me.length;
		}
	}
```

Setting the `selection` edit event to be silent avoids triggering this event. 

To recreate the issue, simply switch the `silent` flag to false and run the tests. The following error is thrown: `this.featureChangeKeys_[e] is undefined`

