### PR TITLE
Change autoLoad setting default to avoid double loading of stores

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -27,10 +27,11 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
 
     /**
      * If autoLoad is true, this store's loadWfs method is automatically called
-     * after creation.
+     * after creation. Note however if remoteFilter is set to true the store
+     * will be automatically loaded regardless of this setting
      * @cfg {Boolean}
      */
-    autoLoad: true,
+    autoLoad: false,
 
     /**
      * Default to using server side sorting
@@ -381,7 +382,6 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
      */
     loadWfs: function() {
         var me = this;
-
         if (me.loadWfsTask_.id === null) {
             me.loadWfsTask_.delay(me.debounce, function() {});
             me.loadWfsInternal();


### PR DESCRIPTION
See https://github.com/geoext/geoext/issues/698#issuecomment-868321322
If `remoteFilter ` is set to `true` the store is autoloaded anyway. 