### PR TITLE
Extract WFS Store parameter creation to its own function

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -376,26 +376,12 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
     },
 
     /**
-     * Loads the data from the connected WFS.
-     * @private
-     */
-    loadWfs: function() {
+     * Create a parameters object used to make a WFS feature request
+     * */
+    createParameters: function () {
+
         var me = this;
 
-        if (me.loadWfsTask_.id === null) {
-            me.loadWfsTask_.delay(me.debounce, function() {});
-            me.loadWfsInternal();
-        } else {
-            me.loadWfsTask_.delay(me.debounce, function() {
-                me.loadWfsInternal();
-            });
-        }
-    },
-
-    loadWfsInternal: function() {
-        var me = this;
-
-        var url = me.url;
         var params = {
             service: me.service,
             version: me.version,
@@ -443,6 +429,32 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
             params.startIndex = me.startIndex;
             params.count = me.pageSize;
         }
+
+        return params;
+    },
+
+    /**
+     * Loads the data from the connected WFS.
+     * @private
+     */
+    loadWfs: function() {
+        var me = this;
+
+        if (me.loadWfsTask_.id === null) {
+            me.loadWfsTask_.delay(me.debounce, function() {});
+            me.loadWfsInternal();
+        } else {
+            me.loadWfsTask_.delay(me.debounce, function() {
+                me.loadWfsInternal();
+            });
+        }
+    },
+
+    loadWfsInternal: function() {
+        var me = this;
+
+        var url = me.url;
+        var params = me.createParameters();
 
         // fire event 'gx-wfsstoreload-beforeload' and skip loading if listener
         // function returns false

--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -377,8 +377,9 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
 
     /**
      * Create a parameters object used to make a WFS feature request
-     * */
-    createParameters: function () {
+     * @return {Object} A object of WFS parameter keys and values
+     */
+    createParameters: function() {
 
         var me = this;
 

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -76,7 +76,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
             });
         });
 
-        it('WFS parameters are created correctly', function () {
+        it('WFS parameters are created correctly', function() {
 
             var store = Ext.create('GeoExt.data.store.WfsFeatures', {
                 url: url,

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -75,6 +75,25 @@ describe('GeoExt.data.store.WfsFeatures', function() {
                 }
             });
         });
+
+        it('WFS parameters are created correctly', function () {
+
+            var store = Ext.create('GeoExt.data.store.WfsFeatures', {
+                url: url,
+                pageSize: 25,
+                srsName: 'EPSG:3857',
+                propertyName: 'FID'
+            });
+
+            var params = store.createParameters();
+
+            expect(params.startIndex).to.be(0);
+            expect(params.count).to.be(25);
+            expect(params.srsName).to.be('EPSG:3857');
+            expect(params.sortBy).to.be('FID ASC');
+            expect(params.filter).to.be(undefined);
+
+        });
     });
 
     describe('loading with paging', function() {

--- a/test/spec/GeoExt/data/store/WfsFeatures.test.js
+++ b/test/spec/GeoExt/data/store/WfsFeatures.test.js
@@ -80,7 +80,7 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
             var store = Ext.create('GeoExt.data.store.WfsFeatures', {
                 url: url,
-                pageSize: 25,
+                count: 25,
                 srsName: 'EPSG:3857',
                 propertyName: 'FID'
             });
@@ -89,10 +89,10 @@ describe('GeoExt.data.store.WfsFeatures', function() {
 
             expect(params.startIndex).to.be(0);
             expect(params.count).to.be(25);
+            expect(params.propertyName).to.be('FID');
             expect(params.srsName).to.be('EPSG:3857');
-            expect(params.sortBy).to.be('FID ASC');
             expect(params.filter).to.be(undefined);
-
+            expect(params.sortBy).to.be(undefined);
         });
     });
 


### PR DESCRIPTION
This pull request moves the WFS request parameter creation out of the `loadWfsInternal` function in `GeoExt.data.store.WfsFeatures` and into its own function.
This allows the store logic to be used to download the contents of the store in another `outputFormat` for example:

```js

        var url = store.url;
        var params = store.createParameters();
        params.outputFormat = 'shapezip'; // change the outputFormat for the current store contents

        // now we can request the same data in the store with a different format (if supported by the WFS server)

        // files can't be downloaded using Ext.Ajax.request (due to browser security)
        // so a hidden form is used with standardSubmit set to true
        // this approach does not allow callbacks to be run on success / failure

        Ext.create('Ext.form.Panel', {
            standardSubmit: true
        }).submit({
            params: params,
            url: url
        });
```