### PR TITLE
Fix broken examples after #686

### DIFF
--- a/examples/features/grid-filter.js
+++ b/examples/features/grid-filter.js
@@ -25,7 +25,8 @@ Ext.application({
         vectorSource = new ol.source.Vector({
             format: new ol.format.GeoJSON({
                 featureProjection: 'EPSG:3857'
-            })
+            }),
+            features: new ol.Collection()
         });
         var vectorLayer = new ol.layer.Vector({
             source: vectorSource
@@ -36,6 +37,7 @@ Ext.application({
             format: new ol.format.GeoJSON({
                 featureProjection: 'EPSG:3857'
             }),
+            features: new ol.Collection(),
             // the loader will load all features via `GET` per default.
             // If a filter is set, request will change to
             // `POST` with valid OGC filter

--- a/examples/features/grid.js
+++ b/examples/features/grid.js
@@ -189,23 +189,24 @@ Ext.application({
             })
         });
 
+        var geojsonFormat = new ol.format.GeoJSON();
         // create a feature collection in order to put into a feature store
-        var vectorSource = new ol.source.Vector({
-            features: (new ol.format.GeoJSON()).readFeatures(geojson1, {
-                dataProjection: 'EPSG:4326',
-                featureProjection: 'EPSG:3857'
-            })
+        var featArray1 = geojsonFormat.readFeatures(geojson1, {
+            dataProjection: 'EPSG:4326',
+            featureProjection: 'EPSG:3857'
         });
-        var featColl = new ol.Collection(vectorSource.getFeatures());
+        var featColl = new ol.Collection(featArray1);
 
         // loading data via into ol source and create a vector layer to bind a
         // vector layer to a feature store
+        var featArray2 = geojsonFormat.readFeatures(geojson2, {
+            dataProjection: 'EPSG:4326',
+            featureProjection: 'EPSG:3857'
+        });
+        var featColl2 = new ol.Collection(featArray2);
         var vectorLayer = new ol.layer.Vector({
             source: new ol.source.Vector({
-                features: (new ol.format.GeoJSON()).readFeatures(geojson2, {
-                    dataProjection: 'EPSG:4326',
-                    featureProjection: 'EPSG:3857'
-                })
+                features: featColl2
             }),
             style: redStyle
         });

--- a/examples/filtered-heatmap/filtered-heatmap.js
+++ b/examples/filtered-heatmap/filtered-heatmap.js
@@ -16,7 +16,9 @@ Ext.application({
     name: 'FilteredHeatmap',
     launch: function() {
         // The OL source which will hold our features
-        var vectorSource = new ol.source.Vector();
+        var vectorSource = new ol.source.Vector({
+            features: new ol.Collection()
+        });
 
         // Loading the vector data manually, so we can avoid using the
         // 'url'-parameter of ol.source.Vector. Otherwise filtering of the


### PR DESCRIPTION
Fixes the following examples:

* https://geoext.github.io/geoext/master/examples/filtered-heatmap/filtered-heatmap.html is broken and fails with `GeoExt.data.store.Features needs to be configured with a feature collection or with a layer with a source with a feature collection`, most probably broken since #686 
* https://geoext.github.io/geoext/master/examples/features/grid.html has the same issue
* https://geoext.github.io/geoext/master/examples/features/grid-filter.html  has the same issue

See #704 