### PR TITLE
Fix the grid map selection example

### DIFF
--- a/examples/features/grid-map-selection.js
+++ b/examples/features/grid-map-selection.js
@@ -1,15 +1,16 @@
+// Configure the loader for the components which you can only use in the
+// classic toolkit.
+Ext.Loader.setPath('GeoExt.selection', '../../classic/selection/');
+
 Ext.require([
     'Ext.container.Container',
     'Ext.panel.Panel',
     'Ext.grid.Panel',
     'GeoExt.component.Map',
-    'GeoExt.data.store.Features'
+    'GeoExt.data.store.Features',
+    // the next can only be resolved when Ext.Loader is configured, see 🔝
+    'GeoExt.selection.FeatureRowModel'
 ]);
-
-// load components, which are only compatible with the classic toolkit
-Ext.Loader.loadScript({
-    url: '../../classic/selection/FeatureRowModel.js'
-});
 
 var olMap;
 var gridWest;


### PR DESCRIPTION
This PR fixes the currently broken https://geoext.github.io/geoext/master/examples/features/grid-map-selection.html example.

See also #704.

Please review.