### PR TITLE
Stabilize OverviewMap creation with custom map

### DIFF
--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -330,10 +330,11 @@ Ext.define('GeoExt.component.OverviewMap', {
     initOverviewMap: function() {
         var me = this;
         var parentMap = me.getParentMap();
+        var ovMap = me.getMap();
 
         me.getLayers().push(me.extentLayer);
 
-        if (!me.getMap()) {
+        if (!ovMap) {
             var parentView = parentMap.getView();
             var olMap = new ol.Map({
                 controls: new ol.Collection(),
@@ -345,6 +346,11 @@ Ext.define('GeoExt.component.OverviewMap', {
                 })
             });
             me.setMap(olMap);
+        } else if (ovMap.getView() && !ovMap.getView().getCenter()) {
+            // OL expects (any) center here.
+            // otherwise problems as described in
+            // https://github.com/geoext/geoext/issues/707 can occur
+            ovMap.getView().setCenter([0, 0]);
         }
 
         GeoExt.util.Layer.cascadeLayers(parentMap.getLayerGroup(),


### PR DESCRIPTION
This fixes the problem described in https://github.com/geoext/geoext/issues/707

When using the OverviewMap with a custom map object, since updating to OL 6.5.0, it is now expected that this custom map object also has (any) center value set. This change assures that there always is a center, even if it was not set on the custom map object that should be used for the overview map.