### PR TITLE
Correct name of geometry attribute in spatial filter example

### DIFF
--- a/examples/features/grid-spatial-filter.js
+++ b/examples/features/grid-spatial-filter.js
@@ -249,7 +249,7 @@ Ext.application({
     onDrawEnd: function(evt) {
         var feature = evt.feature;
         var geometry = feature.getGeometry();
-        var typeName = 'THE_GEOM';
+        var typeName = 'SHAPE';
         var spatialOperatorsCombo = Ext.ComponentQuery.
             query('combobox[name="spatialOperatorsCombo"]')[0];
         var operator = spatialOperatorsCombo.getValue();


### PR DESCRIPTION
The title says it all.

To test:

```
# in repo root
npx serve .
```
Then open http://localhost:3000/examples/features/grid-spatial-filter.html

![Peek 2022-12-15 13-34](https://user-images.githubusercontent.com/227934/207860667-1ff2efe4-cd72-4794-bb73-22ea09b7377e.gif)

