### PR TITLE
Fix issues when serializing OpenLayers icons for printing

### DIFF
--- a/examples/print/basic-mapfish.js
+++ b/examples/print/basic-mapfish.js
@@ -151,7 +151,7 @@ Ext.application({
                     };
                     Ext.create('Ext.form.Panel', {
                         standardSubmit: true,
-                        url: 'https://apps.terrestris.de/print-servlet-3.1.2/' +
+                        url: 'https://apps.terrestris.de/print-servlet-3.29/' +
                             'print/geoext/buildreport.pdf',
                         method: 'POST',
                         items: [
@@ -167,11 +167,12 @@ Ext.application({
         };
 
         Ext.create('GeoExt.data.MapfishPrintProvider', {
-            url: 'https://apps.terrestris.de/print-servlet-3.1.2/' +
+            url: 'https://apps.terrestris.de/print-servlet-3.29/' +
                     'print/geoext/capabilities.json',
             listeners: {
                 ready: onPrintProviderReady
-            }
+            },
+            useJsonp: false
         });
 
         Ext.create('Ext.Viewport', {

--- a/src/data/serializer/Vector.js
+++ b/src/data/serializer/Vector.js
@@ -401,10 +401,10 @@ Ext.define('GeoExt.data.serializer.Vector', {
             } else if (imageStyle instanceof ol.style.Icon) {
                 var src = imageStyle.getSrc();
                 if (Ext.isDefined(src)) {
-                    var img = imageStyle.getImage();
+                    var img = imageStyle.getImage(window.devicePixelRatio || 1);
                     var canvas = document.createElement('canvas');
-                    canvas.width = img.naturalWidth;
-                    canvas.height = img.naturalHeight;
+                    canvas.width = img.naturalWidth || img.width;
+                    canvas.height = img.naturalHeight || img.height;
                     canvas.getContext('2d').drawImage(img, 0, 0);
                     var format = 'image/' + src.match(/\.(\w+)$/)[1];
                     symbolizer = {


### PR DESCRIPTION
Without this the print example errors with

```
Uncaught DOMException: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The image argument is a canvas element with a width or height of 0.
    at Function.encodeVectorStylePoint (https://geoext.github.io/geoext/master/src//data/serializer/Vector.js?_dc=1671108261136:408:45)
```

The used print service has been updated as well, and now the example is working locally again, thanks @dnlkoch.

I think in a follow-up we should remove the option to use `JSONP`, it seems as this is no longer supported. We have the switch `useJsonp` already in teh code, so this can be circumvented in userland easily.

Please review.