### PR TITLE
Fix warnings about "on" symbols in GeoExt.data.store.Layers

### DIFF
--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -36,12 +36,10 @@ Ext.define('GeoExt.data.store.Layers', {
         'ol.Collection#forEach',
         'ol.Collection#getArray',
         'ol.Collection#insertAt',
-        'ol.Collection#on',
         'ol.Collection#push',
         'ol.Collection#remove',
         'ol.layer.Layer',
         'ol.layer.Layer#get',
-        'ol.layer.Layer#on',
         'ol.layer.Layer#set',
         'ol.Map',
         'ol.Map#getLayers'


### PR DESCRIPTION
The `on` events were removed in newer versions of OpenLayers (they were present in 4.6.5 - https://openlayers.org/en/v4.6.5//apidoc/ol.Collection.html#on but not in the latest OL versions). 
In the latest mster version of GeoExt I get the following warnings. This pull request removes the symbols as I don't believe they are now required. 

```
 [W] The class "GeoExt.data.store.Layers" depends on the external symbol "ol.Collection.prototype.on", which does not seem to exist.
 [W] The class "GeoExt.data.store.Layers" depends on the external symbol "ol.layer.Layer.prototype.on", which does not seem to exist.
```