### PR TITLE
Use a maintained GH action to setup ruby

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -24,7 +24,7 @@ jobs:
         java-version: '8'
 
     - name: Install ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
 

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -49,7 +49,7 @@ jobs:
         if (test ! -d ext-6.2.0); then unzip -qo ext-6.2.0-gpl.zip; fi
 
     - name: Install ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
 


### PR DESCRIPTION
The latest merges on master made this obvious:

https://github.com/geoext/geoext/actions/runs/3711233112/jobs/6291441920

![image](https://user-images.githubusercontent.com/227934/208060022-fb8587f4-d126-4464-9729-d07f022217cf.png)

This changes all workflows to use `ruby/setup-ruby@v1` instead of `actions/setup-ruby@v1`

This can most properly be tested once this PR is merged.

Please review @geoext/dev 