### PR TITLE
Fix CI resource copying/referencing (aftermath of ol upgrade)

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -102,8 +102,9 @@ jobs:
         cp -r resources master/
         cp -r src master/
         cp -r classic master/
-        cp -r node_modules/ol master/resources/
-        find master/examples -type f -name "*.html" -exec sed -i 's|../../node_modules/ol|g' {} +
+        cp -r node_modules/ol/dist master/resources/
+        cp node_modules/ol/ol.css master/resources/
+        find master/examples -type f -name "*.html" -exec sed -i 's|../../node_modules/ol|../../resources/|g' {} +
         cp /tmp/sencha-workspace/packages/geoext3/build/*js master/
         npm run generate:docs:master
         npm run generate:docs-w-ext:master


### PR DESCRIPTION
The current CI step is broken as the search and replace action in https://github.com/geoext/geoext/commit/a5f3348fbdb99fc7d01e650f96ba1b7225aca549#diff-06f983058dae83465098c90797cf428d495b8b4e085d07208e61be17203873c0R105-R106 has made the `sed` expression invalid.

This commit changes the CI step so that the files `dist/ol.js` and `dist/ol.js.map` and `ol.css` should be reachable from `master/resources` and the references in the example HTML-files should correctly point to these files.

Again, this is something that can be best tested once merged.

Please review @geoext/dev 
