### PR TITLE
Cosmetic change to the sed action

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -104,7 +104,7 @@ jobs:
         cp -r classic master/
         cp -r node_modules/ol/dist master/resources/
         cp node_modules/ol/ol.css master/resources/
-        find master/examples -type f -name "*.html" -exec sed -i 's|../../node_modules/ol|../../resources/|g' {} +
+        find master/examples -type f -name "*.html" -exec sed -i 's|../../node_modules/ol|../../resources|g' {} +
         cp /tmp/sencha-workspace/packages/geoext3/build/*js master/
         npm run generate:docs:master
         npm run generate:docs-w-ext:master


### PR DESCRIPTION
#723 is working fine, but due to the non-optimal sed command we have duplicated `/` in the hosted examples:

![image](https://user-images.githubusercontent.com/227934/208078381-ee433c01-83bd-4a0c-a6ab-5573cec23716.png)

This PR fixes that.

Please have another look, @geoext/dev (not urgent at all, since everything is working, it's just not nice and neat)