### PR TITLE
Set 'passThroughFilter' to false in WfsFeatureStore

### DIFF
--- a/src/data/store/WfsFeatures.js
+++ b/src/data/store/WfsFeatures.js
@@ -191,6 +191,7 @@ Ext.define('GeoExt.data.store.WfsFeatures', {
         // (if needed)
         var createLayer = config.createLayer;
         config.createLayer = false;
+        config.passThroughFilter = false; // only has effect for layers
 
         me.callParent([config]);
 


### PR DESCRIPTION
This ensures that the inherited config property `passThroughFilter` is forced to `false` within `GeoExt.data.store.WfsFeatures`. This property only has an effect if a vector layer is bound, which is not possible for this type of store.
Furthermore this avoids possible unnecessary requests du to a filter change in the parent class `GeoExt.data.store.Features`, if `passThroughFilter` is set to true, see https://github.com/geoext/geoext/blob/master/src/data/store/Features.js#L189, which causes a reload due to https://github.com/geoext/geoext/blob/master/src/data/store/WfsFeatures.js#L371