### PR TITLE
Update ol to version 8

### DIFF
--- a/examples/component/map.js
+++ b/examples/component/map.js
@@ -16,13 +16,13 @@ Ext.application({
         olMap = new ol.Map({
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'watercolor'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_watercolor'
                     })
                 }),
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'terrain-labels'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_terrain_labels'
                     })
                 })
             ],

--- a/examples/component/overviewMap.js
+++ b/examples/component/overviewMap.js
@@ -59,12 +59,13 @@ Ext.application({
 
         overviewMap1 = Ext.create('GeoExt.component.OverviewMap', {
             parentMap: olMap,
+            magnification: 15,
             layers: [layer2]
         });
 
         overviewMap2 = Ext.create('GeoExt.component.OverviewMap', {
             parentMap: olMap,
-            magnification: 12,
+            magnification: 20,
             layers: [layer3],
             anchorStyle: new ol.style.Style({
                 image: new ol.style.Circle({

--- a/examples/filtered-heatmap/filtered-heatmap.js
+++ b/examples/filtered-heatmap/filtered-heatmap.js
@@ -45,7 +45,7 @@ Ext.application({
         });
 
         var bgLayer = new ol.layer.Tile({
-            source: new ol.source.Stamen({
+            source: new ol.source.StadiaMaps({
                 layer: 'toner'
             })
         });

--- a/examples/mapviewform/mapviewform.js
+++ b/examples/mapviewform/mapviewform.js
@@ -13,14 +13,14 @@ Ext.application({
         });
 
         var layer = new ol.layer.Tile({
-            source: new ol.source.Stamen({
-                layer: 'watercolor'
+            source: new ol.source.StadiaMaps({
+                layer: 'stamen_watercolor'
             })
         });
 
         var labLayer = new ol.layer.Tile({
-            source: new ol.source.Stamen({
-                layer: 'terrain-labels'
+            source: new ol.source.StadiaMaps({
+                layer: 'stamen_terrain_labels'
             })
         });
 

--- a/examples/modern-layerlist/modern-layerlist.js
+++ b/examples/modern-layerlist/modern-layerlist.js
@@ -27,8 +27,8 @@ Ext.application({
                 }),
                 new ol.layer.Tile({
                     name: 'Labels',
-                    source: new ol.source.Stamen({
-                        layer: 'terrain-labels'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_terrain_labels'
                     })
                 }),
                 new ol.layer.Vector({

--- a/examples/modern-map/modern-map.js
+++ b/examples/modern-map/modern-map.js
@@ -21,13 +21,13 @@ Ext.application({
         olMap1 = new ol.Map({
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'watercolor'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_watercolor'
                     })
                 }),
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'terrain-labels'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_terrain_labels'
                     })
                 })
             ],

--- a/examples/popup/gx-popup.js
+++ b/examples/popup/gx-popup.js
@@ -15,13 +15,13 @@ Ext.application({
         olMap = new ol.Map({
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'watercolor'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_watercolor'
                     })
                 }),
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'terrain-labels'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_terrain_labels'
                     })
                 })
             ],

--- a/examples/state/stateful-map.js
+++ b/examples/state/stateful-map.js
@@ -26,13 +26,13 @@ Ext.application({
         olMap = new ol.Map({
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'watercolor'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_watercolor'
                     })
                 }),
                 new ol.layer.Tile({
-                    source: new ol.source.Stamen({
-                        layer: 'terrain-labels'
+                    source: new ol.source.StadiaMaps({
+                        layer: 'stamen_terrain_labels'
                     })
                 })
             ],

--- a/examples/tree/panel.js
+++ b/examples/tree/panel.js
@@ -20,13 +20,13 @@ Ext.application({
         var olMap;
         var treeStore;
 
-        source1 = new ol.source.Stamen({layer: 'watercolor'});
+        source1 = new ol.source.StadiaMaps({layer: 'stamen_watercolor'});
         layer1 = new ol.layer.Tile({
             source: source1,
             name: 'Stamen Watercolor'
         });
 
-        source2 = new ol.source.Stamen({layer: 'terrain-labels'});
+        source2 = new ol.source.StadiaMaps({layer: 'stamen_terrain_labels'});
         layer2 = new ol.layer.Tile({
             source: source2,
             name: 'Stamen Terrain Labels'

--- a/examples/tree/tree-legend-simple.js
+++ b/examples/tree/tree-legend-simple.js
@@ -97,7 +97,7 @@ Ext.application({
         var treeStore2;
 
 
-        source1 = new ol.source.Stamen({layer: 'watercolor'});
+        source1 = new ol.source.StadiaMaps({layer: 'stamen_watercolor'});
         layer1 = new ol.layer.Tile({
             legendUrl: 'https://stamen-tiles-d.a.ssl.fastly.net/' +
                 'watercolor/2/1/0.jpg',
@@ -105,7 +105,7 @@ Ext.application({
             name: 'Stamen Watercolor'
         });
 
-        source2 = new ol.source.Stamen({layer: 'terrain-labels'});
+        source2 = new ol.source.StadiaMaps({layer: 'stamen_terrain_labels'});
         layer2 = new ol.layer.Tile({
             legendUrl: 'https://stamen-tiles-b.a.ssl.fastly.net/' +
                 'terrain-labels/4/4/6.png',

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "mkdirp": "1.0.4",
         "mocha": "10.2.0",
         "np": "7.6.2",
-        "ol": "^7.1.0",
+        "ol": "^8.1.0",
         "rimraf": "3.0.2",
         "sinon": "15.0.1"
       },
@@ -672,49 +672,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.26.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.26.0.tgz",
-      "integrity": "sha512-Ya1WiNz1qYau7xPYPQUbionrw9pjgZAIebGQdDXgwJuSAWeVCr02P7rqbYFHbXqX5TeAaq4qVpcaJb9oZtgaVQ==",
-      "dev": true,
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.6",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      },
-      "bin": {
-        "gl-style-composite": "bin/gl-style-composite.js",
-        "gl-style-format": "bin/gl-style-format.js",
-        "gl-style-migrate": "bin/gl-style-migrate.js",
-        "gl-style-validate": "bin/gl-style-validate.js"
-      }
-    },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-      "dev": true
-    },
-    "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
-      "dev": true
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -751,9 +708,9 @@
       }
     },
     "node_modules/@petamoriken/float16": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.6.tgz",
-      "integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
+      "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ==",
       "dev": true
     },
     "node_modules/@samverschueren/stream-to-observable": {
@@ -2142,12 +2099,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "dev": true
-    },
     "node_modules/custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -3184,22 +3135,34 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.4.tgz",
-      "integrity": "sha512-aG8h9bJccGusioPsEWsEqx8qdXpZN71A20WCvRKGxcnHSOWLKmC5ZmsAmodfxb9TRQvs+89KikGuPzxchhA+Uw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.0.tgz",
+      "integrity": "sha512-B/iFJuFfRpmPHXf8aIRPRgUWwfaNb6dlsynkM8SWeHAPu7CpyvfqEa43KlBt7xxq5OTVysQacFHxhCn3SZhRKQ==",
       "dev": true,
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
-        "lru-cache": "^6.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
         "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2"
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
       },
       "engines": {
-        "browsers": "defaults",
         "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-caller-file": {
@@ -4615,12 +4578,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "node_modules/json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
-    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -5763,12 +5720,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mapbox-to-css-font": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.1.tgz",
-      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow==",
-      "dev": true
-    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6461,30 +6412,19 @@
       }
     },
     "node_modules/ol": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-7.1.0.tgz",
-      "integrity": "sha512-mAeV5Ca4mFhYaJoGWNZnIMN5VNnFTf63FgZjBiYu/DjQDGKNsD5QyvvqVziioVdOOgl6b8rPB/ypj2XNBinPwA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-8.1.0.tgz",
+      "integrity": "sha512-cx3SH2plpFS9fM8pp1nCypgQXGJD7Mcb1E3mEySmy5XEw1DUEo+kkNzgtAZz5qupekqi7aU9iBJEjCoMfqvO2Q==",
       "dev": true,
       "dependencies": {
         "earcut": "^2.2.3",
-        "geotiff": "2.0.4",
-        "ol-mapbox-style": "9.1.0",
+        "geotiff": "^2.0.7",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/openlayers"
-      }
-    },
-    "node_modules/ol-mapbox-style": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-9.1.0.tgz",
-      "integrity": "sha512-R/XE6FdviaXNdnSw6ItHSEreMtQU68cwQCGv4Kl8yG0V1dZhnI5JWr8IOphJwffPVxfWTCnJb5aALGSB89MvhA==",
-      "dev": true,
-      "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1"
       }
     },
     "node_modules/on-finished": {
@@ -7037,9 +6977,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "dev": true
     },
     "node_modules/parent-module": {
@@ -7823,12 +7763,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true
-    },
     "node_modules/rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -8314,37 +8248,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
-      "dev": true,
-      "dependencies": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -9300,9 +9203,9 @@
       }
     },
     "node_modules/xml-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
-      "integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
+      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw==",
       "dev": true
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -9442,6 +9345,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "dev": true
     }
   },
   "dependencies": {
@@ -9927,40 +9836,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
-      "dev": true
-    },
-    "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.26.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.26.0.tgz",
-      "integrity": "sha512-Ya1WiNz1qYau7xPYPQUbionrw9pjgZAIebGQdDXgwJuSAWeVCr02P7rqbYFHbXqX5TeAaq4qVpcaJb9oZtgaVQ==",
-      "dev": true,
-      "requires": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.6",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      }
-    },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-      "dev": true
-    },
-    "@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
-      "dev": true
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9988,9 +9863,9 @@
       }
     },
     "@petamoriken/float16": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.6.tgz",
-      "integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
+      "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ==",
       "dev": true
     },
     "@samverschueren/stream-to-observable": {
@@ -11062,12 +10937,6 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
-    "csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "dev": true
-    },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -11865,18 +11734,27 @@
       "dev": true
     },
     "geotiff": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.4.tgz",
-      "integrity": "sha512-aG8h9bJccGusioPsEWsEqx8qdXpZN71A20WCvRKGxcnHSOWLKmC5ZmsAmodfxb9TRQvs+89KikGuPzxchhA+Uw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.0.tgz",
+      "integrity": "sha512-B/iFJuFfRpmPHXf8aIRPRgUWwfaNb6dlsynkM8SWeHAPu7CpyvfqEa43KlBt7xxq5OTVysQacFHxhCn3SZhRKQ==",
       "dev": true,
       "requires": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
-        "lru-cache": "^6.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
         "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2"
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+          "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+          "dev": true
+        }
       }
     },
     "get-caller-file": {
@@ -12932,12 +12810,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
-      "dev": true
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -13833,12 +13705,6 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
-    "mapbox-to-css-font": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.1.tgz",
-      "integrity": "sha512-QQ/iKiM43DM9+aujTL45Iz5o7gDeSFmy4LPl3HZmNcwCE++NxGazf+yFpY+wCb+YS23sDa1ghpo3zrNFOcHlow==",
-      "dev": true
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -14378,26 +14244,15 @@
       "dev": true
     },
     "ol": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-7.1.0.tgz",
-      "integrity": "sha512-mAeV5Ca4mFhYaJoGWNZnIMN5VNnFTf63FgZjBiYu/DjQDGKNsD5QyvvqVziioVdOOgl6b8rPB/ypj2XNBinPwA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-8.1.0.tgz",
+      "integrity": "sha512-cx3SH2plpFS9fM8pp1nCypgQXGJD7Mcb1E3mEySmy5XEw1DUEo+kkNzgtAZz5qupekqi7aU9iBJEjCoMfqvO2Q==",
       "dev": true,
       "requires": {
         "earcut": "^2.2.3",
-        "geotiff": "2.0.4",
-        "ol-mapbox-style": "9.1.0",
+        "geotiff": "^2.0.7",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
-      }
-    },
-    "ol-mapbox-style": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-9.1.0.tgz",
-      "integrity": "sha512-R/XE6FdviaXNdnSw6ItHSEreMtQU68cwQCGv4Kl8yG0V1dZhnI5JWr8IOphJwffPVxfWTCnJb5aALGSB89MvhA==",
-      "dev": true,
-      "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1"
       }
     },
     "on-finished": {
@@ -14806,9 +14661,9 @@
       }
     },
     "pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "dev": true
     },
     "parent-module": {
@@ -15404,12 +15259,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true
-    },
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -15799,28 +15648,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
-      }
-    },
-    "sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw==",
-      "dev": true
-    },
-    "sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==",
-      "dev": true
-    },
-    "sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
-      "dev": true,
-      "requires": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
       }
     },
     "source-map": {
@@ -16542,9 +16369,9 @@
       "dev": true
     },
     "xml-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
-      "integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
+      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw==",
       "dev": true
     },
     "xmlhttprequest-ssl": {
@@ -16642,6 +16469,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    },
+    "zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "release": "npm run build && np --no-yarn --contents ./dist && git push https://github.com/geoext/geoext.git master --tags"
   },
   "devDependencies": {
-    "ol": "^7.1.0",
+    "ol": "^8.1.0",
     "browser-sync": "2.27.10",
     "copyfiles": "2.4.1",
     "coveralls": "3.1.1",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -112,7 +112,7 @@ module.exports = function(config) {
                     '--no-sandbox',
                     '--headless',
                     '--disable-web-security',
-                    '--disable-gpu',
+                    // '--disable-gpu',
                     // Without a remote debugging port, Google Chrome exits
                     // immediately.
                     '--remote-debugging-port=9999',

--- a/test/spec/GeoExt/data/MapfishPrintProvider.test.js
+++ b/test/spec/GeoExt/data/MapfishPrintProvider.test.js
@@ -198,15 +198,15 @@ describe('GeoExt.data.MapfishPrintProvider', function() {
 
             firstgrouplayer = new ol.layer.Tile({
                 name: '3',
-                source: new ol.source.Stamen({
-                    layer: 'watercolor'
+                source: new ol.source.StadiaMaps({
+                    layer: 'stamen_watercolor'
                 })
             });
 
             secondgrouplayer = new ol.layer.Tile({
                 name: '4',
-                source: new ol.source.Stamen({
-                    layer: 'terrain-labels'
+                source: new ol.source.StadiaMaps({
+                    layer: 'stamen_terrain_labels'
                 })
             });
 

--- a/universal-app.md
+++ b/universal-app.md
@@ -196,13 +196,13 @@ Ext.define("MyGeoExtApp.view.main.Map",{
     map: new ol.Map({
         layers: [
             new ol.layer.Tile({
-                source: new ol.source.Stamen({
-                    layer: 'watercolor'
+                source: new ol.source.StadiaMaps({
+                    layer: 'stamen_watercolor'
                 })
             }),
             new ol.layer.Tile({
-                source: new ol.source.Stamen({
-                    layer: 'terrain-labels'
+                source: new ol.source.StadiaMaps({
+                    layer: 'stamen_terrain_labels'
                 })
             })
         ],


### PR DESCRIPTION
This updates ol to version 8 and adapts the code correspondingly.

Some overviemap tests are failing chrome-headless when the `'--disable-gpu'` flag is activated so this option was outcommented.