### PR TITLE
Use binding for events for OL10

### DIFF
--- a/classic/form/field/GeocoderComboBox.js
+++ b/classic/form/field/GeocoderComboBox.js
@@ -239,7 +239,7 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
      */
     restrictExtent: function() {
         var me = this;
-        me.map.on('moveend', me.updateExtraParams, me);
+        me.map.on('moveend', me.updateExtraParams.bind(me));
         me.updateExtraParams();
     },
 
@@ -296,7 +296,7 @@ Ext.define('GeoExt.form.field.GeocoderComboBox', {
     unRestrictExtent: function() {
         var me = this;
         // unbinding moveend event
-        me.map.un('moveend', me.updateExtraParams, me);
+        me.map.un('moveend', me.updateExtraParams.bind(me));
         // cleanup params in store
         me.removeMapExtentParams();
     },

--- a/classic/selection/FeatureModel.js
+++ b/classic/selection/FeatureModel.js
@@ -136,14 +136,14 @@ Ext.define('GeoExt.selection.FeatureModel', {
         var me = this;
 
         // change style of selected feature
-        me.selectedFeatures.on('add', me.onSelectFeatAdd, me);
+        me.selectedFeatures.on('add', me.onSelectFeatAdd.bind(me));
 
         // reset style of no more selected feature
-        me.selectedFeatures.on('remove', me.onSelectFeatRemove, me);
+        me.selectedFeatures.on('remove', me.onSelectFeatRemove.bind(me));
 
         // create a map click listener for connected vector layer
         if (me.mapSelection && me.layer && me.map) {
-            me.map.on('singleclick', me.onFeatureClick, me);
+            me.map.on('singleclick', me.onFeatureClick.bind(me));
             me.mapClickRegistered = true;
         }
     },
@@ -159,13 +159,13 @@ Ext.define('GeoExt.selection.FeatureModel', {
 
         // remove 'add' / 'remove' listener from selected feature collection
         if (me.selectedFeatures) {
-            me.selectedFeatures.un('add', me.onSelectFeatAdd, me);
-            me.selectedFeatures.un('remove', me.onSelectFeatRemove, me);
+            me.selectedFeatures.un('add', me.onSelectFeatAdd.bind(me));
+            me.selectedFeatures.un('remove', me.onSelectFeatRemove.bind(me));
         }
 
         // remove 'singleclick' listener for connected vector layer
         if (me.mapClickRegistered) {
-            me.map.un('singleclick', me.onFeatureClick, me);
+            me.map.un('singleclick', me.onFeatureClick.bind(me));
             me.mapClickRegistered = false;
         }
     },

--- a/examples/features/grid-spatial-filter.js
+++ b/examples/features/grid-spatial-filter.js
@@ -91,7 +91,7 @@ Ext.application({
             type: 'Polygon'
         });
         drawQueryInteraction.setActive(false);
-        drawQueryInteraction.on('drawend', this.onDrawEnd, this);
+        drawQueryInteraction.on('drawend', this.onDrawEnd.bind(this));
         olMap.addInteraction(drawQueryInteraction);
 
         // create feature store

--- a/src/component/OverviewMap.js
+++ b/src/component/OverviewMap.js
@@ -362,7 +362,7 @@ Ext.define('GeoExt.component.OverviewMap', {
 
         // Set the OverviewMaps center or resolution, on property changed
         // in parentMap.
-        parentMap.getView().on('propertychange', me.onParentViewPropChange, me);
+        parentMap.getView().on('propertychange', me.onParentViewPropChange.bind(me));
 
         // Update the box after rendering a new frame of the parentMap.
         me.enableBoxUpdate();
@@ -391,10 +391,10 @@ Ext.define('GeoExt.component.OverviewMap', {
         dragInteraction.setActive(true);
         // disable the box update during the translation
         // because it interferes when dragging the feature
-        dragInteraction.on('translatestart', me.disableBoxUpdate, me);
-        dragInteraction.on('translating', me.repositionAnchorFeature, me);
-        dragInteraction.on('translateend', me.recenterParentFromBox, me);
-        dragInteraction.on('translateend', me.enableBoxUpdate, me);
+        dragInteraction.on('translatestart', me.disableBoxUpdate.bind(me));
+        dragInteraction.on('translating', me.repositionAnchorFeature.bind(me));
+        dragInteraction.on('translateend', me.recenterParentFromBox.bind(me));
+        dragInteraction.on('translateend', me.enableBoxUpdate.bind(me));
         me.dragInteraction = dragInteraction;
     },
 
@@ -406,7 +406,7 @@ Ext.define('GeoExt.component.OverviewMap', {
         var me = this;
         var parentMap = me.getParentMap();
         if (parentMap) {
-            parentMap.un('postrender', me.updateBox, me);
+            parentMap.un('postrender', me.updateBox.bind(me));
         }
     },
 
@@ -418,7 +418,7 @@ Ext.define('GeoExt.component.OverviewMap', {
         var me = this;
         var parentMap = me.getParentMap();
         if (parentMap) {
-            parentMap.on('postrender', me.updateBox, me);
+            parentMap.on('postrender', me.updateBox.bind(me));
         }
     },
 
@@ -435,10 +435,10 @@ Ext.define('GeoExt.component.OverviewMap', {
         }
         dragInteraction.setActive(false);
         me.getMap().removeInteraction(dragInteraction);
-        dragInteraction.un('translatestart', me.disableBoxUpdate, me);
-        dragInteraction.un('translating', me.repositionAnchorFeature, me);
-        dragInteraction.un('translateend', me.recenterParentFromBox, me);
-        dragInteraction.un('translateend', me.enableBoxUpdate, me);
+        dragInteraction.un('translatestart', me.disableBoxUpdate.bind(me));
+        dragInteraction.un('translating', me.repositionAnchorFeature.bind(me));
+        dragInteraction.un('translateend', me.recenterParentFromBox.bind(me));
+        dragInteraction.un('translateend', me.enableBoxUpdate.bind(me));
         me.dragInteraction = null;
     },
 
@@ -656,9 +656,9 @@ Ext.define('GeoExt.component.OverviewMap', {
             return shallRecenter;
         }
         if (shallRecenter) {
-            map.on('click', me.overviewMapClicked, me);
+            map.on('click', me.overviewMapClicked.bind(me));
         } else {
-            map.un('click', me.overviewMapClicked, me);
+            map.un('click', me.overviewMapClicked.bind(me));
         }
         return shallRecenter;
     },
@@ -702,7 +702,7 @@ Ext.define('GeoExt.component.OverviewMap', {
 
         if (map) {
             // unbind recenter listener, if any
-            map.un('click', me.overviewMapClicked, me);
+            map.un('click', me.overviewMapClicked.bind(me));
         }
 
         me.destroyDragBehaviour();
@@ -710,7 +710,7 @@ Ext.define('GeoExt.component.OverviewMap', {
         if (parentMap) {
             // unbind parent listeners
             me.disableBoxUpdate();
-            parentView.un('propertychange', me.onParentViewPropChange, me);
+            parentView.un('propertychange', me.onParentViewPropChange.bind(me));
         }
     },
 

--- a/src/component/Popup.js
+++ b/src/component/Popup.js
@@ -161,7 +161,7 @@ Ext.define('GeoExt.component.Popup', {
 
         me.getMap().addOverlay(overlay);
         // fix layout of popup when its position changes
-        overlay.on('change:position', me.updateLayout, me);
+        overlay.on('change:position', me.updateLayout.bind(me));
 
         // make accessible as member
         me.setOverlay(overlay);
@@ -195,6 +195,6 @@ Ext.define('GeoExt.component.Popup', {
             var parent = me.overlayElement.parentNode;
             parent.removeChild(me.overlayElement);
         }
-        me.getOverlay().un('change:position', me.doLayout, me);
+        me.getOverlay().un('change:position', me.doLayout.bind(me));
     }
 });

--- a/src/data/model/LayerTreeNode.js
+++ b/src/data/model/LayerTreeNode.js
@@ -80,7 +80,7 @@ Ext.define('GeoExt.data.model.LayerTreeNode', {
         layer = this.getOlLayer();
         if (layer instanceof ol.layer.Base) {
             this.set('checked', layer.get('visible'));
-            layer.on('change:visible', this.onLayerVisibleChange, this);
+            layer.on('change:visible', this.onLayerVisibleChange.bind(this));
         }
     },
 

--- a/src/data/model/OlObject.js
+++ b/src/data/model/OlObject.js
@@ -101,7 +101,7 @@ Ext.define('GeoExt.data.model.OlObject', {
         // init record with properties of underlying ol object
         me.callParent([this.olObject.getProperties()]);
 
-        me.olObject.on('propertychange', me.onPropertychange, me);
+        me.olObject.on('propertychange', me.onPropertychange.bind(me));
     },
 
     /**
@@ -158,7 +158,7 @@ Ext.define('GeoExt.data.model.OlObject', {
      * @inheritdoc
      */
     destroy: function() {
-        this.olObject.un('propertychange', this.onPropertychange, this);
+        this.olObject.un('propertychange', this.onPropertychange.bind(me));
 
         this.callParent(arguments);
     }

--- a/src/data/store/Features.js
+++ b/src/data/store/Features.js
@@ -153,8 +153,8 @@ Ext.define('GeoExt.data.store.Features', {
         }
 
         if (cfg.features instanceof ol.Collection) {
-            this.olCollection.on('add', this.onOlCollectionAdd, this);
-            this.olCollection.on('remove', this.onOlCollectionRemove, this);
+            this.olCollection.on('add', this.onOlCollectionAdd.bind(this));
+            this.olCollection.on('remove', this.onOlCollectionRemove.bind(this));
         }
         me.bindLayerEvents();
 
@@ -238,8 +238,8 @@ Ext.define('GeoExt.data.store.Features', {
      */
     destroy: function() {
         if (this.olCollection) {
-            this.olCollection.un('add', this.onCollectionAdd, this);
-            this.olCollection.un('remove', this.onCollectionRemove, this);
+            this.olCollection.un('add', this.onCollectionAdd.bind(this));
+            this.olCollection.un('remove', this.onCollectionRemove.bind(this));
         }
 
         var me = this;
@@ -287,8 +287,8 @@ Ext.define('GeoExt.data.store.Features', {
         var me = this;
         if (me.layer && me.layer.getSource() instanceof ol.source.Vector) {
             // bind feature add / remove events of the layer
-            me.layer.getSource().on('addfeature', me.onFeaturesAdded, me);
-            me.layer.getSource().on('removefeature', me.onFeaturesRemoved, me);
+            me.layer.getSource().on('addfeature', me.onFeaturesAdded.bind(me));
+            me.layer.getSource().on('removefeature', me.onFeaturesRemoved.bind(me));
         }
     },
 
@@ -301,8 +301,8 @@ Ext.define('GeoExt.data.store.Features', {
         var me = this;
         if (me.layer && me.layer.getSource() instanceof ol.source.Vector) {
             // unbind feature add / remove events of the layer
-            me.layer.getSource().un('addfeature', me.onFeaturesAdded, me);
-            me.layer.getSource().un('removefeature', me.onFeaturesRemoved, me);
+            me.layer.getSource().un('addfeature', me.onFeaturesAdded.bind(me));
+            me.layer.getSource().un('removefeature', me.onFeaturesRemoved.bind(me));
         }
     },
 

--- a/src/data/store/Layers.js
+++ b/src/data/store/Layers.js
@@ -116,10 +116,11 @@ Ext.define('GeoExt.data.store.Layers', {
         });
 
         mapLayers.forEach(function(layer) {
-            layer.on('propertychange', me.onChangeLayer, me);
+            layer.on('propertychange', me.onChangeLayer.bind(me));
         });
-        mapLayers.on('add', me.onAddLayer, me);
-        mapLayers.on('remove', me.onRemoveLayer, me);
+
+        mapLayers.on('add', me.onAddLayer.bind(me));
+        mapLayers.on('remove', me.onRemoveLayer.bind(me));
 
         me.on({
             'load': me.onLoad,
@@ -163,8 +164,8 @@ Ext.define('GeoExt.data.store.Layers', {
         var me = this;
 
         if (me.layers) {
-            me.layers.un('add', me.onAddLayer, me);
-            me.layers.un('remove', me.onRemoveLayer, me);
+            me.layers.un('add', me.onAddLayer.bind(me));
+            me.layers.un('remove', me.onRemoveLayer.bind(me));
         }
         me.un('load', me.onLoad, me);
         me.un('clear', me.onClear, me);
@@ -227,7 +228,7 @@ Ext.define('GeoExt.data.store.Layers', {
         var layer = evt.element;
         var index = this.layers.getArray().indexOf(layer);
         var me = this;
-        layer.on('propertychange', me.onChangeLayer, me);
+        layer.on('propertychange', me.onChangeLayer.bind(me));
         if (!me._adding) {
             me._adding = true;
             var result = me.proxy.reader.read(layer);
@@ -249,7 +250,7 @@ Ext.define('GeoExt.data.store.Layers', {
             var rec = me.getByLayer(layer);
             if (rec) {
                 me._removing = true;
-                layer.un('propertychange', me.onChangeLayer, me);
+                layer.un('propertychange', me.onChangeLayer.bind(me));
                 me.remove(rec);
                 delete me._removing;
             }
@@ -273,7 +274,7 @@ Ext.define('GeoExt.data.store.Layers', {
             if (!me._addRecords) {
                 me._removing = true;
                 me.layers.forEach(function(layer) {
-                    layer.un('propertychange', me.onChangeLayer, me);
+                    layer.un('propertychange', me.onChangeLayer.bind(me));
                 });
                 me.layers.getLayers().clear();
                 delete me._removing;
@@ -283,7 +284,7 @@ Ext.define('GeoExt.data.store.Layers', {
                 var layers = new Array(len);
                 for (var i = 0; i < len; i++) {
                     layers[i] = records[i].getOlLayer();
-                    layers[i].on('propertychange', me.onChangeLayer, me);
+                    layers[i].on('propertychange', me.onChangeLayer.bind(me));
                 }
                 me._adding = true;
                 me.layers.extend(layers);
@@ -302,7 +303,7 @@ Ext.define('GeoExt.data.store.Layers', {
         var me = this;
         me._removing = true;
         me.layers.forEach(function(layer) {
-            layer.un('propertychange', me.onChangeLayer, me);
+            layer.un('propertychange', me.onChangeLayer.bind(me));
         });
         me.layers.clear();
         delete me._removing;
@@ -325,7 +326,7 @@ Ext.define('GeoExt.data.store.Layers', {
             var layer;
             for (var i = 0, ii = records.length; i < ii; ++i) {
                 layer = records[i].getOlLayer();
-                layer.on('propertychange', me.onChangeLayer, me);
+                layer.on('propertychange', me.onChangeLayer.bind(me));
                 if (index === 0) {
                     me.layers.push(layer);
                 } else {
@@ -363,7 +364,7 @@ Ext.define('GeoExt.data.store.Layers', {
                 record = records[i];
                 layer = record.getOlLayer();
                 found = false;
-                layer.un('propertychange', me.onChangeLayer, me);
+                layer.un('propertychange', me.onChangeLayer.bind(me));
                 me.layers.forEach(compareFunc);
                 if (found) {
                     me._removing = true;

--- a/src/data/store/LayersTree.js
+++ b/src/data/store/LayersTree.js
@@ -379,9 +379,9 @@ Ext.define('GeoExt.data.store.LayersTree', {
         var me = this;
         if (layerOrGroup instanceof ol.layer.Group) {
             var collection = layerOrGroup.getLayers();
-            collection.on('remove', me.onLayerCollectionRemove, me);
-            collection.on('add', me.onLayerCollectionAdd, me);
-            collection.forEach(me.bindGroupLayerCollectionEvents, me);
+            collection.on('remove', me.onLayerCollectionRemove.bind(me));
+            collection.on('add', me.onLayerCollectionAdd.bind(me));
+            collection.forEach(me.bindGroupLayerCollectionEvents.bind(me));
         }
     },
 
@@ -397,9 +397,9 @@ Ext.define('GeoExt.data.store.LayersTree', {
         var me = this;
         if (layerOrGroup instanceof ol.layer.Group) {
             var collection = layerOrGroup.getLayers();
-            collection.un('remove', me.onLayerCollectionRemove, me);
-            collection.un('add', me.onLayerCollectionAdd, me);
-            collection.forEach(me.unbindGroupLayerCollectionEvents, me);
+            collection.un('remove', me.onLayerCollectionRemove.bind(me));
+            collection.un('add', me.onLayerCollectionAdd.bind(me));
+            collection.forEach(me.unbindGroupLayerCollectionEvents.bind(me));
         }
     },
 


### PR DESCRIPTION
When updating to OL10 the scope can no longer be passed as a parameter using `on` and `un`. See https://github.com/openlayers/openlayers/blob/main/changelog/upgrade-notes.md#removal-of-optional-this-arguments-1

These calls are all changed to using binding to set scope:

`this.olCollection.on('add', this.onOlCollectionAdd, this);` to `this.olCollection.on('add', this.onOlCollectionAdd.bind(this));`
