### PR TITLE
Add v prefix to docs output to match GitHub branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "coveralls": "cat coverage/lcov.info | coveralls",
     "generate:example": "node bin/example-generator/index.js",
     "generate:docs:master": "jsdoc -c .jsdoc.json -d master/docs",
-    "generate:docs:tag": "jsdoc -c .jsdoc.json -d $npm_package_version/docs",
+    "generate:docs:tag": "jsdoc -c .jsdoc.json -d v$npm_package_version/docs",
     "postversion": "cp package.json dist/",
     "release": "npm run build && np --no-yarn --contents ./dist && git push https://github.com/geoext/geoext.git master --tags"
   },


### PR DESCRIPTION
The tag docs folder doesn't currently match the package.json version (v7.0.0 and 7.0.0) stopping tagged releases documentation deploying automatically. See https://github.com/geoext/geoext/actions/runs/12280911563/job/34268488061

```
  [INFO] clean up /home/runner/actions_github_pages_1733935398523/${GITHUB_REF##*/}
  [INFO] chdir /home/runner/actions_github_pages_1733935398523/${GITHUB_REF##*/}
  /usr/bin/git rm -r --ignore-unmatch *
  [INFO] chdir /home/runner/actions_github_pages_1733935398523
  [INFO] prepare publishing assets
  [INFO] copy /home/runner/work/geoext/geoext/${GITHUB_REF##*/} to /home/runner/actions_github_pages_1733935398523/${GITHUB_REF##*/}
  cp: no such file or directory: /home/runner/work/geoext/geoext/${GITHUB_REF##*/}/*
  cp: no such file or directory: /home/runner/work/geoext/geoext/${GITHUB_REF##*/}/.*
```